### PR TITLE
Add global .jsx file exclude pattern

### DIFF
--- a/src/main/scala/codacy/jshint/JSHint.scala
+++ b/src/main/scala/codacy/jshint/JSHint.scala
@@ -38,8 +38,9 @@ object JSHint extends Tool {
       .getOrElse(Success(Option.empty[Path])).map { maybeConfig =>
 
       val configPart = maybeConfig.map { path => List("--config", path.toAbsolutePath.toString) }.getOrElse(List.empty)
+      val excludePart = List("--exclude", "./**/*.jsx")
       val finalPath = files.getOrElse(Set(source)).map(_.path)
-      val cmd = List("jshint") ++ configPart ++ List("--verbose") ++ finalPath
+      val cmd = List("jshint") ++ configPart ++ excludePart ++ List("--verbose") ++ finalPath
 
       CommandRunner.exec(cmd, Option(File(source.path).toJava)) match {
         case Right(resultFromTool) =>


### PR DESCRIPTION
# Add global .jsx file exclude pattern

## Problem

Even with a `.jshintignore` file, the contents of which contain a glob such as the following, JSHint seems keen on attempting to lint `.jsx` files.

```
some/relative/path/to/**/*.jsx

```

## Proposed Solution

Globally ignoring `.jsx` files.

## Expected Results

JSHint should not lint `.jsx` files at all, whether or not a `.jshintignore` file exists and accounts for them.
